### PR TITLE
Remove Illuminate version for Laravel 5.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "illuminate/support": ">=5.2.15 <5.3.0",
-        "illuminate/database": ">=5.2.15 <5.3.0",
+        "illuminate/support": ">=5.2.15",
+        "illuminate/database": ">=5.2.15",
         "crate/crate-dbal": "0.2.*"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 5.3 requires Illuminate 5.3.x, which is a higher version than this repository allows. Removed the maximum version number, so that it can be used on the latest stable version of Laravel.
