### PR TITLE
Correctly print array and object SQL parameters in case of an exception.

### DIFF
--- a/src/RatkoR/Crate/Connection.php
+++ b/src/RatkoR/Crate/Connection.php
@@ -3,6 +3,7 @@
 namespace RatkoR\Crate;
 
 use Closure;
+use Exception;
 use RatkoR\Crate\Schema\Builder;
 use Crate\DBAL\Driver\PDOCrate\Driver as DoctrineDriver;
 use RatkoR\Crate\Query\Grammars\Grammar as QueryGrammar;

--- a/src/RatkoR/Crate/Connection.php
+++ b/src/RatkoR/Crate/Connection.php
@@ -2,12 +2,14 @@
 
 namespace RatkoR\Crate;
 
+use Closure;
 use RatkoR\Crate\Schema\Builder;
 use Crate\DBAL\Driver\PDOCrate\Driver as DoctrineDriver;
 use RatkoR\Crate\Query\Grammars\Grammar as QueryGrammar;
 use RatkoR\Crate\Schema\Grammars\Grammar as SchemaGrammar;
 use Crate\PDO\PDO;
 use RatkoR\Crate\Query\Builder as QueryBuilder;
+use RatkoR\Crate\QueryException as QueryException;
 
 class Connection extends \Illuminate\Database\Connection
 {
@@ -195,4 +197,43 @@ class Connection extends \Illuminate\Database\Connection
             $this, $this->getQueryGrammar(), $this->getPostProcessor()
         );
     }
+
+   /**
+     * Crate works with extended fields like arrays and objects. If
+     * exception is triggered, laravel logs SQL and
+     * it's parameters. While doing this it casts parameters to
+     * string which then fails in it's default QueryException with:
+     *    ErrorException: Object of class stdClass could not be converted to string
+     *
+     * We're overriding runQueryCallback to trigger our own
+     * version of QueryException.
+     * 
+     * @param  string    $query
+     * @param  array     $bindings
+     * @param  \Closure  $callback
+     * @return mixed
+     *
+     * @throws \Illuminate\Database\QueryException
+     */
+    protected function runQueryCallback($query, $bindings, Closure $callback)
+    {
+        // To execute the statement, we'll simply call the callback, which will actually
+        // run the SQL against the PDO connection. Then we can calculate the time it
+        // took to execute and log the query SQL, bindings and time in our memory.
+        try {
+            $result = $callback($this, $query, $bindings);
+        }
+
+        // If an exception occurs when attempting to run a query, we'll format the error
+        // message to include the bindings with SQL, which will make this exception a
+        // lot more helpful to the developer instead of just the database's errors.
+        catch (Exception $e) {
+            throw new QueryException(
+                $query, $this->prepareBindings($bindings), $e
+            );
+        }
+
+        return $result;
+    }
+
 }

--- a/src/RatkoR/Crate/QueryException.php
+++ b/src/RatkoR/Crate/QueryException.php
@@ -3,6 +3,7 @@
 namespace RatkoR\Crate;
 
 use Illuminate\Database\QueryException as BaseQueryException;
+use Illuminate\Support\Str;
 
 class QueryException extends BaseQueryException
 {
@@ -19,15 +20,15 @@ class QueryException extends BaseQueryException
      */
     protected function formatMessage($sql, $bindings, $previous)
     {
-        $stringCasted = $this->valuesToStrings($bindings);
+        $preparedBindings = $this->prepareBindings($bindings);
 
-        return $previous->getMessage().' (SQL: '.Str::replaceArray('?', $bindings, $sql).')';
+        return $previous->getMessage().' (SQL: '.Str::replaceArray('?', $preparedBindings, $sql).')';
     }
 
     /**
      * Non scalar fields are json_encoded to string values.
      */
-    protected function valuesToStrings($bindings)
+    protected function prepareBindings($bindings)
     {
         foreach ($bindings as $key => $binding) {
             $bindings[$key] = is_scalar($binding) ?

--- a/src/RatkoR/Crate/QueryException.php
+++ b/src/RatkoR/Crate/QueryException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace RatkoR\Crate;
+
+use Illuminate\Database\QueryException as BaseQueryException;
+
+class QueryException extends BaseQueryException
+{
+
+    /**
+     * Format the SQL error message.
+     * 
+     * Overriden to support extended types like arrays and objects.
+     *
+     * @param  string  $sql
+     * @param  array  $bindings
+     * @param  \Exception $previous
+     * @return string
+     */
+    protected function formatMessage($sql, $bindings, $previous)
+    {
+        $stringCasted = $this->valuesToStrings($bindings);
+
+        return $previous->getMessage().' (SQL: '.Str::replaceArray('?', $bindings, $sql).')';
+    }
+
+    /**
+     * Non scalar fields are json_encoded to string values.
+     */
+    protected function valuesToStrings($bindings)
+    {
+        foreach ($bindings as $key => $binding) {
+            $bindings[$key] = is_scalar($binding) ?
+                                $binding : json_encode($binding);
+        }
+
+        return $bindings;
+    }
+}

--- a/tests/DataTests/DataTest.php
+++ b/tests/DataTests/DataTest.php
@@ -301,7 +301,7 @@ class DataTest extends TestCase {
 
     /**
      * @test
-     * @expectedException Crate\PDO\Exception\PDOException
+     * @expectedException RatkoR\Crate\QueryException
      * @expectedExceptionMessage cannot cast {bar=test} to string
      */
     public function it_throws_meaningful_error()

--- a/tests/DataTests/DataTest.php
+++ b/tests/DataTests/DataTest.php
@@ -298,4 +298,17 @@ class DataTest extends TestCase {
         $this->assertEquals('user2@example.com', $user_2[0]['email']);
         $this->assertEquals('user3@example.com', $user_3[0]['email']);
     }
+
+    /**
+     * @test
+     * @expectedException Crate\PDO\Exception\PDOException
+     * @expectedExceptionMessage cannot cast {bar=test} to string
+     */
+    public function it_throws_meaningful_error()
+    {
+        $foo = new stdClass();
+        $foo->bar = 'test';
+
+        User::create(['id'=>1,'name'=> $foo,'email'=>'user1@example.com']);
+    }
 }


### PR DESCRIPTION
Laravel tries to show SQL that caused an exception. While doing it
it also prints all SQL parameters. If there are arrays or objects
in parameter it throws an "Object of class stdClass
could not be converted to string" exception.

This commit json_encodes all non scalar parameters so that they can
be printed in exception.