### PR TITLE
A migration table in laravel is not creating because of throw excepti…

### DIFF
--- a/src/RatkoR/Crate/Schema/Blueprint.php
+++ b/src/RatkoR/Crate/Schema/Blueprint.php
@@ -319,8 +319,7 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint {
      */
     public function increments($column)
     {
-        throw new NotImplementedException('Auto increments are not supported in Crate.io');
-
+        //throw new NotImplementedException('Auto increments are not supported in Crate.io');
     }
 
     /**

--- a/src/RatkoR/Crate/Schema/Blueprint.php
+++ b/src/RatkoR/Crate/Schema/Blueprint.php
@@ -319,7 +319,13 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint {
      */
     public function increments($column)
     {
-        //throw new NotImplementedException('Auto increments are not supported in Crate.io');
+
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $is_from_create_repository = collect($backtrace)->pluck('function')->contains('createRepository');
+
+        if(!$is_from_create_repository)
+            throw new NotImplementedException('Auto increments are not supported in Crate.io');
+
     }
 
     /**


### PR DESCRIPTION
I've installed Laravel 5.7.16 and laravel-crate.io 7.0.0.
End an empty database.
Then I want to create a migration table and invoke my migrations.
I type: php artisan migrate:refresh --seed
And get the error:  Auto increments are not supported in Crate.io

A migration table in laravel is not creating because of throwing an exception in the Blueprint.php -> increments, I suggest to comment out exception throwing to allow a migration table creation without errors.