### PR TITLE
Change timestamp

### DIFF
--- a/src/RatkoR/Crate/Eloquent/Model.php
+++ b/src/RatkoR/Crate/Eloquent/Model.php
@@ -18,7 +18,7 @@ class Model extends BaseModel
     * created_at, updated_at and similar fields are
     * timespamp fields, not datetime.
     */
-    public $dateFormat = 'U';
+    public $dateFormat = 'c';
 
     /**
      * Get a new query builder instance for the connection.

--- a/src/RatkoR/Crate/Eloquent/Model.php
+++ b/src/RatkoR/Crate/Eloquent/Model.php
@@ -18,10 +18,7 @@ class Model extends BaseModel
     * created_at, updated_at and similar fields are
     * timespamp fields, not datetime.
     */
-    public function getDateFormat()
-    {
-        return 'U';
-    }
+    public $dateFormat = 'U';
 
     /**
      * Get a new query builder instance for the connection.


### PR DESCRIPTION
I changed the default timestamp to a ISO 8601 Date.  
With the timestamp all dates were wrong in the database. With the `c` format it does work.  
I changed the way the dateFormat gets resolved aswell. Now it is easier to overwrite the default dateFormat.