### PR TITLE
feat: add partitioningBy and generated Columns

### DIFF
--- a/src/RatkoR/Crate/Schema/Blueprint.php
+++ b/src/RatkoR/Crate/Schema/Blueprint.php
@@ -32,7 +32,7 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint {
      *
      * @var array
      */
-    protected $partionedBy = [];
+    protected $partitionedBy = [];
 
     /**
      * Returns all fulltext indexes.
@@ -51,7 +51,7 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint {
      */
     public function partitionedBy($colums)
     {
-        $this->partionedBy = Arr::wrap($colums);
+        $this->partitionedBy = Arr::wrap($colums);
     }
 
     /**
@@ -61,7 +61,7 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint {
      */
     public function getPartitionedBy()
     {
-        return $this->partionedBy;
+        return $this->partitionedBy;
     }
 
     /**

--- a/src/RatkoR/Crate/Schema/Blueprint.php
+++ b/src/RatkoR/Crate/Schema/Blueprint.php
@@ -5,6 +5,7 @@ namespace RatkoR\Crate\Schema;
 use Closure;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Grammars\Grammar;
+use Illuminate\Support\Arr;
 use RatkoR\Crate\NotImplementedException;
 
 class Blueprint extends \Illuminate\Database\Schema\Blueprint {
@@ -26,6 +27,14 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint {
     protected $indexes = [];
 
     /**
+     * This Array is used to partition the Crate Table into multiple parts.
+     * This is a advanced feature in create and should be used with caution
+     *
+     * @var array
+     */
+    protected $partionedBy = [];
+
+    /**
      * Returns all fulltext indexes.
      *
      * @return array
@@ -33,6 +42,26 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint {
     public function getIndexes()
     {
         return $this->indexes;
+    }
+
+    /**
+     * set PartionendBy for Table
+     *
+     * @param  string|array  $columns
+     */
+    public function partitionedBy($colums)
+    {
+        $this->partionedBy = Arr::wrap($colums);
+    }
+
+    /**
+     * Returns all fulltext indexes.
+     *
+     * @return array
+     */
+    public function getPartitionedBy()
+    {
+        return $this->partionedBy;
     }
 
     /**
@@ -124,6 +153,17 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint {
     public function ip($column)
     {
         return $this->addColumn('ip', $column);
+    }
+
+    /**
+     * generated field
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function generated($column)
+    {
+        return $this->addColumn('generated', $column);
     }
 
     /**


### PR DESCRIPTION
Table creation syntax now includes table partitioning see. https://crate.io/docs/crate/reference/en/latest/general/ddl/partitioned-tables.html
Generated columns can be created via a migration https://crate.io/docs/crate/reference/en/latest/general/ddl/generated-columns.html#sql-ddl-generated-columns