### PR TITLE
Work around croaking test suite

### DIFF
--- a/tests/DataTests/Migrations/2015_04_08_185200_create_users_table.php
+++ b/tests/DataTests/Migrations/2015_04_08_185200_create_users_table.php
@@ -13,6 +13,7 @@ class CreateUsersTable extends Migration {
      */
     public function up()
     {
+        if (Schema::hasTable('t_users')) return;
         Schema::create('t_users', function(Blueprint $table)
         {
             $table->integer('id');


### PR DESCRIPTION
Dear Ratko,

first things first: Thanks a stack for conceiving and maintaining this excellent driver.

We just tried invoking the test suite on a fresh clone of the repository, and found it croaks right away like
```
There was 1 error:

1) DataTests\DataTest::it_adds_a_multiple_users
RatkoR\Crate\QueryException: RelationAlreadyExists[Relation 'doc.t_users' already exists.] (SQL: create table "t_users" ("id" integer, "name" string, "email" string, "password" string, "f_array" array (string), "f_object" object , "remember_token" string, "created_at" timestamp, "updated_at" timestamp ) )
```

It looks like the test suite is invoking `CreateUsersTable.up` multiple times, without balancing it correctly with its `CreateUsersTable.down` counterpart.

The patch is probably wrong, but it makes the test suite succeed on our end. Maybe something has to be adjusted or fixed on the PhpUnit-level instead?

With kind regards,
Andreas.

```
$ composer --version
Composer version 2.4.2 2022-09-14 16:11:15
```