### PR TITLE
Fix running tests with ./run_tests.sh

### DIFF
--- a/tests/DataTests/DataTest.php
+++ b/tests/DataTests/DataTest.php
@@ -9,15 +9,23 @@ use StdClass;
 
 class DataTest extends TestCase {
 
+    protected static $testNb = 0;
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        static::$testNb++;
 
         $this->app->singleton('migration.repository', function ($app) {
             $table = $app['config']['database.migrations'];
 
             return new \DataTests\Fixture\DatabaseMigrationRepository($app['db'], $table);
         });
+
+        if (static::$testNb === 2) {
+            sleep(1);
+        }
 
         Artisan::call('migrate', [
             '--database' => 'crate',


### PR DESCRIPTION
When running tests with ./run_tests.sh phpunit fails with:

```
Crate\PDO\Exception\PDOException: RelationAlreadyExists[Relation 'doc.t_users' already exists.
```

Seems that this happens because migrations are run too fast. Each test in DataTest.php runs migration to have clear DB. Migrations before first and second tests have to have some time inbetween or else the above error happens.