### PR TITLE
DBAL3: Permit installation up to crate-dbal 5.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-pdo": "*",
         "illuminate/support": "^10.0",
         "illuminate/database": "^10.0",
-        "crate/crate-dbal": "^2.0|^3.0.0"
+        "crate/crate-dbal": "^3|^4|^5"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
_Note: This patch is stacked upon GH-51, please process that one first._

## About

[crate-dbal 5.0.0](https://packagist.org/packages/crate/crate-dbal#5.0.0) has been released, adding support for DBAL3.

## Status
Software tests appear to be successful.
```
$ ./vendor/bin/phpunit
PHPUnit 9.6.29 by Sebastian Bergmann and contributors.

................................................................. 65 / 84 ( 77%)
...................                                               84 / 84 (100%)

Time: 00:03.224, Memory: 30.00 MB

OK (84 tests, 171 assertions)
```

> Outlook: Would it be good to have a little CI/GHA configuration to validate the module on each PR against CrateDB nightly? Edit: See GH-52.

## References
- https://github.com/crate/crate-dbal/pull/122
